### PR TITLE
Issue #147 - Activity Time stored in UTC

### DIFF
--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -97,12 +97,10 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False):
         return months
 
     if not show_date:
-        now = datetime.datetime.utcnow()
-        if datetime_.tzinfo is not None:
-            now = now.replace(tzinfo=datetime_.tzinfo)
-        else:
-            now = now.replace(tzinfo=pytz.utc)
-            datetime_ = datetime_.replace(tzinfo=pytz.utc)
+        now = datetime.datetime.now(pytz.utc)
+        if datatime_.tzinfo is None:
+            datetime_ = datetime_.astimezone(pytz.utc)
+
         date_diff = now - datetime_
         days = date_diff.days
         if days < 1 and now > datetime_:

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -38,7 +38,7 @@ class Activity(domain_object.DomainObject):
     def __init__(self, user_id, object_id, revision_id, activity_type,
             data=None):
         self.id = _types.make_uuid()
-        self.timestamp = datetime.datetime.now()
+        self.timestamp = datetime.datetime.utcnow()
         self.user_id = user_id
         self.object_id = object_id
         self.revision_id = revision_id


### PR DESCRIPTION
bcgov/ckanext-bcgov#147 ckan/ckan#2882 ckan/ckan#2970

The Activity model now stores its timestamp in utc

In Formatters, localized_nice_date, removed the datetime replace method
calls with actually ensuring the comparing timestamps have a timezone
specified.

Note that this **does not** fix activity times that already have a stored timestamp. I'm not sure on the approach to fixing that. I'm inclined to just leave old timestamps, as they don't seem like they're very crucial (but this isn't my call)
