### PR TITLE
Removing pkg_dict assignment in parent template

### DIFF
--- a/ckan/templates/package/edit_base.html
+++ b/ckan/templates/package/edit_base.html
@@ -1,7 +1,6 @@
 {% extends 'package/base.html' %}
 
 {% set pkg = c.pkg_dict %}
-{% set pkg_dict = c.pkg_dict %}
 
 {% block breadcrumb_content_selected %}{% endblock %}
 


### PR DESCRIPTION
Forgot to add this to the bcgov ckan fork.

Reason being is for OFI prototype, related: bcgov/ckanext-bcgov#178
